### PR TITLE
feat: add dashboard_yaml support for Atmos-native dashboard configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ recommended Atmos-native approach as it enables:
 
 - **Deep merging**: Compose dashboards from multiple stack layers
 - **Inheritance**: Define base dashboard configurations and extend them
-- **Atmos functions**: Use `!terraform.output`, `!atmos.component`, and other Atmos template functions
+- **Atmos functions**: Use `!terraform.output`, `!terraform.state`, and other Atmos template functions
 
 ```yaml
 components:

--- a/README.yaml
+++ b/README.yaml
@@ -69,7 +69,7 @@ usage: |-
 
   - **Deep merging**: Compose dashboards from multiple stack layers
   - **Inheritance**: Define base dashboard configurations and extend them
-  - **Atmos functions**: Use `!terraform.output`, `!atmos.component`, and other Atmos template functions
+  - **Atmos functions**: Use `!terraform.output`, `!terraform.state`, and other Atmos template functions
 
   ```yaml
   components:

--- a/README.yaml
+++ b/README.yaml
@@ -11,9 +11,20 @@ usage: |-
   > This component requires **OpenTofu 1.7+** or **Terraform 1.9+** for the `templatestring()` function.
   > Earlier versions will encounter errors like `Function not found: templatestring`.
 
+  ## Dashboard Configuration Methods
+
+  This component supports three mutually exclusive methods for providing dashboard configuration.
+  **Exactly one** of `dashboard_url`, `dashboard_file`, or `dashboard_yaml` must be set.
+
+  | Method | Use Case |
+  |--------|----------|
+  | `dashboard_url` | Load dashboards from remote URLs (e.g., Grafana marketplace) |
+  | `dashboard_file` | Load dashboards from local JSON files in the `dashboards/` directory |
+  | `dashboard_yaml` | Define dashboards inline in Atmos stack configuration using YAML |
+
   ### Loading a Dashboard from URL
 
-  Here's an example snippet for loading a dashboard from the Grafana marketplace.
+  Use `dashboard_url` to load a dashboard from a remote endpoint such as the Grafana marketplace.
 
   ```yaml
   components:
@@ -33,7 +44,7 @@ usage: |-
 
   ### Loading a Dashboard from Local File
 
-  You can also load dashboards from local JSON files stored in the `dashboards/` directory within the component.
+  Use `dashboard_file` to load dashboards from local JSON files stored in the `dashboards/` directory within the component.
 
   ```yaml
   components:
@@ -51,10 +62,156 @@ usage: |-
             "${DS_CLOUDWATCH}": "acme-plat-ue2-sandbox-cloudwatch"
   ```
 
+  ### Defining a Dashboard with YAML (Atmos Native)
+
+  Use `dashboard_yaml` to define the dashboard configuration directly in your Atmos stack files. This is the
+  recommended Atmos-native approach as it enables:
+
+  - **Deep merging**: Compose dashboards from multiple stack layers
+  - **Inheritance**: Define base dashboard configurations and extend them
+  - **Atmos functions**: Use `!terraform.output`, `!atmos.component`, and other Atmos template functions
+
+  ```yaml
+  components:
+    terraform:
+      grafana/dashboard/custom:
+        metadata:
+          component: managed-grafana/dashboard
+        vars:
+          enabled: true
+          name: "custom-dashboard"
+          grafana_component_name: grafana
+          grafana_api_key_component_name: grafana/api-key
+          dashboard_yaml:
+            annotations:
+              list:
+                - builtIn: 1
+                  datasource:
+                    type: grafana
+                    uid: "-- Grafana --"
+                  enable: true
+                  hide: true
+                  iconColor: "rgba(0, 211, 255, 1)"
+                  name: Annotations & Alerts
+                  type: dashboard
+            editable: true
+            fiscalYearStartMonth: 0
+            graphTooltip: 0
+            panels:
+              - datasource:
+                  type: cloudwatch
+                  uid: "${DS_CLOUDWATCH}"
+                fieldConfig:
+                  defaults:
+                    color:
+                      mode: palette-classic
+                    thresholds:
+                      mode: absolute
+                      steps:
+                        - color: green
+                          value: null
+                        - color: red
+                          value: 80
+                  overrides: []
+                gridPos:
+                  h: 8
+                  w: 12
+                  x: 0
+                  y: 0
+                id: 1
+                options:
+                  legend:
+                    calcs: []
+                    displayMode: list
+                    placement: bottom
+                    showLegend: true
+                  tooltip:
+                    mode: single
+                    sort: none
+                targets:
+                  - datasource:
+                      type: cloudwatch
+                      uid: "${DS_CLOUDWATCH}"
+                    dimensions:
+                      ClusterName: my-cluster
+                    expression: ""
+                    id: ""
+                    matchExact: true
+                    metricEditorMode: 0
+                    metricName: CPUUtilization
+                    metricQueryType: 0
+                    namespace: AWS/ECS
+                    period: ""
+                    queryMode: Metrics
+                    refId: A
+                    region: default
+                    statistic: Average
+                title: ECS CPU Utilization
+                type: timeseries
+            refresh: ""
+            schemaVersion: 39
+            templating:
+              list: []
+            time:
+              from: now-6h
+              to: now
+            timepicker: {}
+            timezone: browser
+          config_input:
+            "${DS_CLOUDWATCH}": "acme-plat-ue2-sandbox-cloudwatch"
+  ```
+
+  #### Using Inheritance with `dashboard_yaml`
+
+  Define a base dashboard in your catalog and extend it in environment-specific stacks:
+
+  ```yaml
+  # stacks/catalog/grafana/dashboards/base.yaml
+  components:
+    terraform:
+      grafana/dashboard/base:
+        metadata:
+          component: managed-grafana/dashboard
+          type: abstract
+        vars:
+          grafana_component_name: grafana
+          grafana_api_key_component_name: grafana/api-key
+          dashboard_yaml:
+            editable: true
+            schemaVersion: 39
+            time:
+              from: now-6h
+              to: now
+            timezone: browser
+  ```
+
+  ```yaml
+  # stacks/orgs/acme/plat/sandbox/us-east-2/grafana.yaml
+  import:
+    - catalog/grafana/dashboards/base
+
+  components:
+    terraform:
+      grafana/dashboard/ecs-metrics:
+        metadata:
+          component: managed-grafana/dashboard
+          inherits:
+            - grafana/dashboard/base
+        vars:
+          enabled: true
+          name: "ecs-metrics"
+          dashboard_yaml:
+            panels:
+              - title: ECS CPU
+                type: timeseries
+                # ... panel configuration
+  ```
+
   ### Variable Substitution
 
   The `config_input` variable accepts a map of string replacements. These are applied using the `templatestring()` function,
-  which replaces `${VAR}` placeholders in the dashboard JSON with the corresponding values.
+  which replaces `${VAR}` placeholders in the dashboard configuration with the corresponding values. This works with all
+  three dashboard configuration methods.
 
   <!-- prettier-ignore-start -->
   <!-- prettier-ignore-end -->

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,14 +1,25 @@
 locals {
   enabled = module.this.enabled
 
-  # Determine if using URL or local file
+  # Determine which dashboard source is being used
   use_url  = var.dashboard_url != ""
   use_file = var.dashboard_file != ""
+  use_yaml = var.dashboard_yaml != null
 
-  # Load dashboard JSON from either URL or local file
+  # Load dashboard configuration from one of three sources:
+  # 1. URL: Fetch from remote endpoint (e.g., Grafana marketplace)
+  # 2. File: Load from local JSON file in dashboards/ directory
+  # 3. YAML: Use inline configuration passed via Atmos stack variables
+  #
   # Only access data.http when enabled and using URL (count > 0)
   # Top-level guard on local.enabled prevents file() from being evaluated when disabled
-  dashboard_json_raw = local.enabled ? (local.use_url ? data.http.grafana_dashboard_json[0].response_body : (local.use_file ? file("${path.module}/dashboards/${var.dashboard_file}") : "{}")) : "{}"
+  dashboard_json_raw = local.enabled ? (
+    local.use_url ? data.http.grafana_dashboard_json[0].response_body : (
+      local.use_file ? file("${path.module}/dashboards/${var.dashboard_file}") : (
+        local.use_yaml ? jsonencode(var.dashboard_yaml) : "{}"
+      )
+    )
+  ) : "{}"
 
   # Apply variable substitutions from config_input to the merged JSON
   # Uses templatestring() to replace ${VAR} placeholders with values (OpenTofu 1.7+)

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -10,18 +10,13 @@ variable "dashboard_name" {
 
 variable "dashboard_url" {
   type        = string
-  description = "The marketplace URL of the dashboard to be created. Either this or dashboard_file must be set."
+  description = "The marketplace URL of the dashboard to be created. Exactly one of `dashboard_url`, `dashboard_file`, or `dashboard_yaml` must be set."
   default     = ""
-
-  validation {
-    condition     = (var.dashboard_url != "" && var.dashboard_file == "") || (var.dashboard_url == "" && var.dashboard_file != "")
-    error_message = "Exactly one of dashboard_url or dashboard_file must be set, but not both."
-  }
 }
 
 variable "dashboard_file" {
   type        = string
-  description = "Filename of a local dashboard JSON file in the component's dashboards directory. Must be a simple filename (no path separators). Either this or dashboard_url must be set."
+  description = "Filename of a local dashboard JSON file in the component's dashboards directory. Must be a simple filename (no path separators). Exactly one of `dashboard_url`, `dashboard_file`, or `dashboard_yaml` must be set."
   default     = ""
 
   validation {
@@ -32,6 +27,21 @@ variable "dashboard_file" {
   validation {
     condition     = var.dashboard_file == "" || can(regex("^[A-Za-z0-9_-]+\\.json$", var.dashboard_file))
     error_message = "The dashboard_file must be a simple filename matching the pattern [A-Za-z0-9_-]+.json (e.g., 'my-dashboard.json')."
+  }
+}
+
+variable "dashboard_yaml" {
+  type        = any
+  description = "Dashboard configuration defined as YAML/HCL in Atmos stack configuration. This allows defining dashboards inline using Atmos features like deep merging, inheritance, and Atmos functions. Exactly one of `dashboard_url`, `dashboard_file`, or `dashboard_yaml` must be set."
+  default     = null
+
+  validation {
+    condition = (
+      (var.dashboard_url != "" ? 1 : 0) +
+      (var.dashboard_file != "" ? 1 : 0) +
+      (var.dashboard_yaml != null ? 1 : 0)
+    ) == 1
+    error_message = "Exactly one of dashboard_url, dashboard_file, or dashboard_yaml must be set."
   }
 }
 


### PR DESCRIPTION
## What
Adds a third method for providing dashboard configuration: `dashboard_yaml`. This allows defining Grafana dashboards directly in Atmos stack configuration as YAML/HCL.

The component now supports three mutually exclusive methods:
- `dashboard_url` - Load from remote URL (e.g., Grafana marketplace)
- `dashboard_file` - Load from local JSON file in `dashboards/` directory
- `dashboard_yaml` - Define inline in Atmos stack configuration

## Why
While URL and file-based methods are useful for consuming pre-built dashboards, the Atmos-native approach of defining configuration in YAML enables:

- **Deep merging**: Compose dashboards from multiple stack layers
- **Inheritance**: Define base dashboard configurations in catalog and extend them per-environment
- **Atmos functions**: Use template functions like `!terraform.output` and `!terraform.state`
- **Version control**: Dashboard changes are tracked alongside other infrastructure configuration

This follows the Atmos pattern of defining everything as stackable, mergeable YAML configuration.

## References
- Builds on #40 which added `dashboard_file` support
- Follows pattern established by other Atmos-native configuration approaches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for inline YAML dashboard configuration as a third, mutually exclusive option (dashboard_yaml) alongside URL and file methods; supports inheritance, deep merging, and templating.

* **Documentation**
  * Expanded README with clear guidance, examples, and usage scenarios for all three dashboard configuration methods, including YAML examples, inheritance patterns, and updated input descriptions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->